### PR TITLE
Add JSON tags to structs and configure SQLC for custom Go types

### DIFF
--- a/_bruno/Platform/All Platforms.yml
+++ b/_bruno/Platform/All Platforms.yml
@@ -44,11 +44,11 @@ examples:
         data: |-
           [
             {
-              "ID": 3,
-              "Name": "Platform 1",
-              "Description": "An Example Platform",
-              "CreatedAt": "2026-04-21T20:28:39.996859-05:00",
-              "UpdatedAt": "2026-04-21T20:28:39.996859-05:00"
+              "id": 3,
+              "name": "Platform 1",
+              "description": "An Example Platform",
+              "created_at": "2026-04-21T20:28:39.996859-05:00",
+              "updated_at": "2026-04-21T20:28:39.996859-05:00"
             }
           ]
 

--- a/_bruno/Platform/Platform By Id.yml
+++ b/_bruno/Platform/Platform By Id.yml
@@ -51,11 +51,11 @@ examples:
         type: json
         data: |-
           {
-            "ID": 3,
-            "Name": "Platform 1",
-            "Description": "An Example Platform",
-            "CreatedAt": "2026-04-21T20:28:39.996859-05:00",
-            "UpdatedAt": "2026-04-21T20:28:39.996859-05:00"
+            "id": 3,
+            "name": "Platform 1",
+            "description": "An Example Platform",
+            "created_at": "2026-04-21T20:28:39.996859-05:00",
+            "updated_at": "2026-04-21T20:28:39.996859-05:00"
           }
 
 docs: |-

--- a/_bruno/Product/Get Product By ID.yml
+++ b/_bruno/Product/Get Product By ID.yml
@@ -37,12 +37,12 @@ examples:
         type: json
         data: |-
           {
-            "ID": 1,
-            "PlatformID": 1,
-            "Name": "Example Product",
-            "Description": "An example product description",
-            "CreatedAt": "2026-05-04T19:17:00Z",
-            "UpdatedAt": "2026-05-04T19:17:00Z"
+            "id": 1,
+            "platform_id": 1,
+            "name": "Example Product",
+            "description": "An example product description",
+            "created_at": "2026-05-04T19:17:00Z",
+            "updated_at": "2026-05-04T19:17:00Z"
           }
 
 docs: |-

--- a/_bruno/Product/Get Products By Platform.yml
+++ b/_bruno/Product/Get Products By Platform.yml
@@ -38,20 +38,20 @@ examples:
         data: |-
           [
             {
-              "ID": 1,
-              "PlatformID": 1,
-              "Name": "Product 1",
-              "Description": "Description 1",
-              "CreatedAt": "2026-05-04T19:17:00Z",
-              "UpdatedAt": "2026-05-04T19:17:00Z"
+              "id": 1,
+              "platform_id": 1,
+              "name": "Product 1",
+              "description": "Description 1",
+              "created_at": "2026-05-04T19:17:00Z",
+              "updated_at": "2026-05-04T19:17:00Z"
             },
             {
-              "ID": 2,
-              "PlatformID": 1,
-              "Name": "Product 2",
-              "Description": "Description 2",
-              "CreatedAt": "2026-05-04T19:17:00Z",
-              "UpdatedAt": "2026-05-04T19:17:00Z"
+              "id": 2,
+              "platform_id": 1,
+              "name": "Product 2",
+              "description": "Description 2",
+              "created_at": "2026-05-04T19:17:00Z",
+              "updated_at": "2026-05-04T19:17:00Z"
             }
           ]
 

--- a/internal/platform/handler_test.go
+++ b/internal/platform/handler_test.go
@@ -496,10 +496,10 @@ func TestUpdatePlatform(t *testing.T) {
 						if arg.Description.String != expectedBody.Description.String {
 							t.Errorf("expected Description %s, got %s", expectedBody.Description.String, arg.Description.String)
 						}
-						if !arg.Updatedat.Valid {
+						if !arg.UpdatedAt.Valid {
 							t.Error("expected UpdatedAt to be valid")
 						}
-						if arg.Updatedat.Time.IsZero() {
+						if arg.UpdatedAt.Time.IsZero() {
 							t.Error("expected UpdatedAt to be non-zero")
 						}
 					}

--- a/internal/platform/models.gen.go
+++ b/internal/platform/models.gen.go
@@ -9,34 +9,34 @@ import (
 )
 
 type Flow struct {
-	ID          int32
-	ProductID   int32
-	Name        string
-	Description pgtype.Text
-	CreatedAt   pgtype.Timestamptz
-	UpdatedAt   pgtype.Timestamptz
+	ID          int32              `json:"id"`
+	ProductID   int32              `json:"product_id"`
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 }
 
 type FlowStep struct {
-	ID      int32
-	FlowID  int32
-	Current pgtype.UUID
-	Next    pgtype.UUID
+	ID      int32       `json:"id"`
+	FlowID  int32       `json:"flow_id"`
+	Current pgtype.UUID `json:"current"`
+	Next    pgtype.UUID `json:"next"`
 }
 
 type Platform struct {
-	ID          int32
-	Name        string
-	Description pgtype.Text
-	CreatedAt   pgtype.Timestamptz
-	UpdatedAt   pgtype.Timestamptz
+	ID          int32              `json:"id"`
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 }
 
 type Product struct {
-	ID          int32
-	PlatformID  int32
-	Name        string
-	Description pgtype.Text
-	CreatedAt   pgtype.Timestamptz
-	UpdatedAt   pgtype.Timestamptz
+	ID          int32              `json:"id"`
+	PlatformID  int32              `json:"platform_id"`
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 }

--- a/internal/platform/platforms.sql
+++ b/internal/platform/platforms.sql
@@ -9,7 +9,7 @@ SELECT id, name, description, created_at, updated_at FROM platforms WHERE id = @
 INSERT INTO platforms (name, description, created_at, updated_at) VALUES (@name, @description, @timeStamp, @timeStamp);
 
 -- name: UpdatePlatform :one
-UPDATE platforms SET name = @name, description = @description, updated_at = @updatedAt WHERE id = @id RETURNING id;
+UPDATE platforms SET name = @name, description = @description, updated_at = @updated_at WHERE id = @id RETURNING id;
 
 -- name: DeletePlatform :one
 DELETE FROM platforms WHERE id = @id RETURNING id;

--- a/internal/platform/platforms.sql.gen.go
+++ b/internal/platform/platforms.sql.gen.go
@@ -16,9 +16,9 @@ INSERT INTO platforms (name, description, created_at, updated_at) VALUES ($1, $2
 `
 
 type CreatePlatformParams struct {
-	Name        string
-	Description pgtype.Text
-	Timestamp   pgtype.Timestamptz
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	Timestamp   pgtype.Timestamptz `json:"timestamp"`
 }
 
 func (q *Queries) CreatePlatform(ctx context.Context, arg CreatePlatformParams) error {
@@ -88,10 +88,10 @@ UPDATE platforms SET name = $1, description = $2, updated_at = $3 WHERE id = $4 
 `
 
 type UpdatePlatformParams struct {
-	Name        string
-	Description pgtype.Text
-	Updatedat   pgtype.Timestamptz
-	ID          int32
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	Updatedat   pgtype.Timestamptz `json:"updatedat"`
+	ID          int32              `json:"id"`
 }
 
 func (q *Queries) UpdatePlatform(ctx context.Context, arg UpdatePlatformParams) (int32, error) {

--- a/internal/platform/platforms.sql.gen.go
+++ b/internal/platform/platforms.sql.gen.go
@@ -90,7 +90,7 @@ UPDATE platforms SET name = $1, description = $2, updated_at = $3 WHERE id = $4 
 type UpdatePlatformParams struct {
 	Name        string             `json:"name"`
 	Description pgtype.Text        `json:"description"`
-	Updatedat   pgtype.Timestamptz `json:"updatedat"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 	ID          int32              `json:"id"`
 }
 
@@ -98,7 +98,7 @@ func (q *Queries) UpdatePlatform(ctx context.Context, arg UpdatePlatformParams) 
 	row := q.db.QueryRow(ctx, updatePlatform,
 		arg.Name,
 		arg.Description,
-		arg.Updatedat,
+		arg.UpdatedAt,
 		arg.ID,
 	)
 	var id int32

--- a/internal/platform/request.go
+++ b/internal/platform/request.go
@@ -39,7 +39,7 @@ func (r *updatePlatformRequest) ToParams(id int32) UpdatePlatformParams {
 			Valid:  r.Description != "",
 			String: r.Description,
 		},
-		Updatedat: pgtype.Timestamptz{
+		UpdatedAt: pgtype.Timestamptz{
 			Valid: true,
 			Time:  time.Now().UTC(),
 		},

--- a/internal/platform/request_test.go
+++ b/internal/platform/request_test.go
@@ -69,10 +69,10 @@ func TestUpdatePlatformRequest_ToParams(t *testing.T) {
 	if params.Description.String != req.Description {
 		t.Errorf("expected description %q, got %q", req.Description, params.Description.String)
 	}
-	if !params.Updatedat.Valid {
+	if !params.UpdatedAt.Valid {
 		t.Error("expected updatedat to be valid")
 	}
-	diff := time.Since(params.Updatedat.Time)
+	diff := time.Since(params.UpdatedAt.Time)
 	if diff < 0 {
 		diff = -diff
 	}

--- a/internal/product/models.gen.go
+++ b/internal/product/models.gen.go
@@ -9,34 +9,34 @@ import (
 )
 
 type Flow struct {
-	ID          int32
-	ProductID   int32
-	Name        string
-	Description pgtype.Text
-	CreatedAt   pgtype.Timestamptz
-	UpdatedAt   pgtype.Timestamptz
+	ID          int32              `json:"id"`
+	ProductID   int32              `json:"product_id"`
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 }
 
 type FlowStep struct {
-	ID      int32
-	FlowID  int32
-	Current pgtype.UUID
-	Next    pgtype.UUID
+	ID      int32       `json:"id"`
+	FlowID  int32       `json:"flow_id"`
+	Current pgtype.UUID `json:"current"`
+	Next    pgtype.UUID `json:"next"`
 }
 
 type Platform struct {
-	ID          int32
-	Name        string
-	Description pgtype.Text
-	CreatedAt   pgtype.Timestamptz
-	UpdatedAt   pgtype.Timestamptz
+	ID          int32              `json:"id"`
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 }
 
 type Product struct {
-	ID          int32
-	PlatformID  int32
-	Name        string
-	Description pgtype.Text
-	CreatedAt   pgtype.Timestamptz
-	UpdatedAt   pgtype.Timestamptz
+	ID          int32              `json:"id"`
+	PlatformID  int32              `json:"platform_id"`
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 }

--- a/internal/product/products.sql.gen.go
+++ b/internal/product/products.sql.gen.go
@@ -16,10 +16,10 @@ INSERT INTO products (platform_id, name, description, created_at, updated_at) VA
 `
 
 type CreateProductParams struct {
-	PlatformID  int32
-	Name        string
-	Description pgtype.Text
-	Timestamp   pgtype.Timestamptz
+	PlatformID  int32              `json:"platform_id"`
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	Timestamp   pgtype.Timestamptz `json:"timestamp"`
 }
 
 func (q *Queries) CreateProduct(ctx context.Context, arg CreateProductParams) error {
@@ -96,11 +96,11 @@ UPDATE products SET platform_id = $1, name = $2, description = $3, updated_at = 
 `
 
 type UpdateProductParams struct {
-	PlatformID  int32
-	Name        string
-	Description pgtype.Text
-	UpdatedAt   pgtype.Timestamptz
-	ID          int32
+	PlatformID  int32              `json:"platform_id"`
+	Name        string             `json:"name"`
+	Description pgtype.Text        `json:"description"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+	ID          int32              `json:"id"`
 }
 
 func (q *Queries) UpdateProduct(ctx context.Context, arg UpdateProductParams) (int32, error) {

--- a/sqlc.yml
+++ b/sqlc.yml
@@ -12,6 +12,16 @@ sql:
         output_files_suffix: ".gen.go"
         output_querier_file_name: "querier.gen.go"
         emit_interface: true
+        emit_json_tags: true
+        overrides:
+          - db_type: "timestamp"
+            go_type: "github.com/jackc/pgx/v5/pgtype.Timestamptz"
+          - db_type: "timestamptz"
+            go_type: "github.com/jackc/pgx/v5/pgtype.Timestamptz"
+          - db_type: "uuid"
+            go_type: "github.com/jackc/pgx/v5/pgtype.UUID"
+          - db_type: "text"
+            go_type: "github.com/jackc/pgx/v5/pgtype.Text"
 
   - engine: "postgresql"
     queries: "internal/product/products.sql"
@@ -25,3 +35,13 @@ sql:
         output_files_suffix: ".gen.go"
         output_querier_file_name: "querier.gen.go"
         emit_interface: true
+        emit_json_tags: true
+        overrides:
+          - db_type: "timestamp"
+            go_type: "github.com/jackc/pgx/v5/pgtype.Timestamptz"
+          - db_type: "timestamptz"
+            go_type: "github.com/jackc/pgx/v5/pgtype.Timestamptz"
+          - db_type: "uuid"
+            go_type: "github.com/jackc/pgx/v5/pgtype.UUID"
+          - db_type: "text"
+            go_type: "github.com/jackc/pgx/v5/pgtype.Text"


### PR DESCRIPTION
- Add `json` tags to all relevant structs for consistent API compatibility.
- Update `sqlc.yml` to enable JSON tags and define custom Go types for PostgreSQL types (e.g., `timestamp`, `uuid`, `text`).
- Regenerate SQLC files to reflect updated configurations and include JSON tags in generated code.
- Update example JSON payloads in Bruno collections to align with new tag format (lowercase keys).

## Description

<!-- Provide a short description of what this PR is changing -->
### Code Rabbit Summary
<!-- This section allows Code Rabbit to generate a summary -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * API examples and sample responses updated to use consistent snake_case JSON field names across platform and product endpoints (e.g., id, platform_id, created_at, updated_at) replacing prior PascalCase keys in documented responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fixes
<!-- Add any issues that this PR closes here -->
Closes #47 

## Post Deployment Tasks?
